### PR TITLE
[Serializer] Correct typing mistake in DocBlock

### DIFF
--- a/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
+++ b/src/Symfony/Component/Serializer/Normalizer/CustomNormalizer.php
@@ -48,7 +48,7 @@ class CustomNormalizer extends SerializerAwareNormalizer implements NormalizerIn
     }
 
     /**
-     * Checks if the given class implements the NormalizableInterface.
+     * Checks if the given class implements the DenormalizableInterface.
      *
      * @param mixed  $data   Data to denormalize from.
      * @param string $type   The class to which the data should be denormalized.


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | 4.0
| Bug fix?      | yes (comment only)
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | na
| Fixed tickets | na
| License       | MIT
| Doc PR        |

DocBlock comment referred to `NormalizableInterface` but code was using `DenormalizableInterface`
